### PR TITLE
Using atoi function to convert char to integer

### DIFF
--- a/examples/tls_client_example/tls_client_example.c
+++ b/examples/tls_client_example/tls_client_example.c
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
 
     if (argc > 2) {
         hostname = argv[1];
-        port_number = argv[2];
+        port_number = atoi(argv[2]);
     }
     else
         hostname = "localhost";

--- a/examples/tls_server_example/tls_server_example.c
+++ b/examples/tls_server_example/tls_server_example.c
@@ -106,7 +106,7 @@ main(int argc, char** argv)
 {
     int port_number = 8102;
     if (argc > 1)
-        port_number = argv[1];
+        port_number = atoi(argv[1]);
 
     printf("Using libIEC61850 version %s\n", LibIEC61850_getVersionString());
     printf("libIEC61850 IedServer server will listen on %d\n", port_number);


### PR DESCRIPTION
Using `atoi` function to convert argv[2] to integer port number.