### PR TITLE
Add const char to fix warning message

### DIFF
--- a/examples/no_tls_server_example/no_tls_server_example.c
+++ b/examples/no_tls_server_example/no_tls_server_example.c
@@ -288,7 +288,7 @@ static MmsDataAccessError
 writeAccessHandler (DataAttribute* dataAttribute, MmsValue* value, ClientConnection connection, void* parameter)
 {
     if (dataAttribute == IEDMODEL_GenericIO_GGIO1_NamPlt_vendor) {
-        char* newValue = MmsValue_toString(value);
+        const char* newValue = MmsValue_toString(value);
         printf("New value for OutVarSet_setMag_f = %s\n", newValue);
         fflush(stdout);
         int compared_result = strcmp(newValue, INVERTER_ON_STRING);

--- a/examples/tls_server_example/tls_server_example.c
+++ b/examples/tls_server_example/tls_server_example.c
@@ -29,7 +29,7 @@ static MmsDataAccessError
 writeAccessHandler (DataAttribute* dataAttribute, MmsValue* value, ClientConnection connection, void* parameter)
 {
     if (dataAttribute == IEDMODEL_GenericIO_GGIO1_NamPlt_vendor) {
-        char* newValue = MmsValue_toString(value);
+        const char* newValue = MmsValue_toString(value);
         printf("New value for OutVarSet_setMag_f = %s\n", newValue);
         return DATA_ACCESS_ERROR_SUCCESS;
     }


### PR DESCRIPTION
# Changed log

- Fixing `const` warning message for using/calling the `MmsValue_toString` function.